### PR TITLE
Only pass haml files to the  HamlLint::Runner

### DIFF
--- a/lib/pronto/haml.rb
+++ b/lib/pronto/haml.rb
@@ -10,17 +10,17 @@ module Pronto
     def run(patches, _)
       return [] unless patches
 
-      patches.select { |patch| patch.additions > 0 }.
-        select { |patch| haml_file?(patch.new_file_full_path) }.
-        map { |patch| inspect(patch) }.
-        flatten.compact
+      patches.select { |patch| patch.additions > 0 }
+        .select { |patch| haml_file?(patch.new_file_full_path) }
+        .map { |patch| inspect(patch) }
+        .flatten.compact
     end
 
     def inspect(patch)
       lints = @runner.run(files: [patch.new_file_full_path.to_s]).lints
       lints.map do |lint|
         patch.added_lines.select { |line| line.new_lineno == lint.line }
-                         .map { |line| new_message(lint, line) }
+          .map { |line| new_message(lint, line) }
       end
     end
 

--- a/lib/pronto/haml.rb
+++ b/lib/pronto/haml.rb
@@ -10,8 +10,10 @@ module Pronto
     def run(patches, _)
       return [] unless patches
 
-      valid_patches = patches.select { |patch| patch.additions > 0 }
-      valid_patches.map { |patch| inspect(patch) }.flatten.compact
+      patches.select { |patch| patch.additions > 0 }.
+        select { |patch| haml_file?(patch.new_file_full_path) }.
+        map { |patch| inspect(patch) }.
+        flatten.compact
     end
 
     def inspect(patch)
@@ -25,6 +27,12 @@ module Pronto
     def new_message(lint, line)
       path = line.patch.delta.new_file[:path]
       Message.new(path, line, lint.severity, lint.message)
+    end
+
+    private
+
+    def haml_file?(path)
+      File.extname(path) == '.haml'
     end
   end
 end

--- a/spec/pronto/haml_spec.rb
+++ b/spec/pronto/haml_spec.rb
@@ -12,9 +12,25 @@ module Pronto
         it { should == [] }
       end
 
-      context 'no patches' do
+      context 'patches are empty' do
         let(:patches) { [] }
         it { should == [] }
+      end
+    end
+
+    context 'private instance methods' do
+      describe '#haml_file?' do
+        subject { haml.send(:haml_file?, path) }
+
+        context 'with haml format' do
+          let(:path) { 'bar/foo.html.haml' }
+          it { should == true }
+        end
+
+        context 'with other file format' do
+          let(:path) { 'bar/foo.erb' }
+          it { should == false }
+        end
       end
     end
   end


### PR DESCRIPTION
Hey Mindaugas,

I restricted the gem to only forward patches on haml files to the HamlLint::Runner. 
In some cases the haml-lint gem has been executed on non-haml files. 
Any thoughts?

Hope you can merge/release this soon. Thanks!
Martin